### PR TITLE
Add tinydb stubs with Meson build and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # tinydb
+
+A tiny, educational SQLite-like database in C++20.
+
+## Build
+
+```bash
+meson setup build
+meson compile -C build
+meson test -C build --print-errorlogs
+./build/cli/tinydb
+```
+

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+int main() {
+    std::cout << "tinydb CLI (stub)\n";
+    std::cout << "Type SQL or Ctrl-D to exit.\n";
+    return 0;
+}
+

--- a/cli/meson.build
+++ b/cli/meson.build
@@ -1,1 +1,7 @@
-executable('tinydb', 'main.cpp', dependencies: tinydb_dep)
+exe = executable('tinydb', 'main.cpp',
+  include_directories: inc,
+  dependencies: tinydb_dep,
+  install: false
+)
+alias_target('tinydb_cli', exe)
+

--- a/docs/file_format.md
+++ b/docs/file_format.md
@@ -1,1 +1,5 @@
-# File Format
+# File Format (v0)
+
+- Page size: 4096
+- Leaf cell: [varint key][varint payload_len][payload]
+

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,1 +1,8 @@
 # Roadmap
+
+Phase 1: Pager
+Phase 2: Varint + Record
+Phase 3: B-Tree
+Phase 4: VM
+Phase 5: Parser + Codegen
+

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -1,1 +1,4 @@
-# Stack
+# Execution Stack
+
+SQL → Tokenizer → Parser → Semantic → Planner → Codegen → VM → B-Tree → Pager → File
+

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,1 +1,5 @@
 # Testing
+
+- Unit tests per module
+- Golden files under tests/golden/
+

--- a/include/tinydb/ast.hpp
+++ b/include/tinydb/ast.hpp
@@ -1,0 +1,3 @@
+#pragma once
+// Placeholder for shared AST helpers if needed later.
+

--- a/include/tinydb/btree.hpp
+++ b/include/tinydb/btree.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#include <cstdint>
+#include <string_view>
+#include <vector>
+#include "tinydb/pager.hpp"
+
+namespace tinydb {
+
+struct Key { int64_t rowid{0}; };
+
+class Cursor {
+public:
+    uint32_t root{0};
+    int idx{0};
+};
+
+class BTree {
+public:
+    explicit BTree(Pager& p);
+    uint32_t create_table();
+    void insert(uint32_t root, Key k, std::string_view payload);
+    Cursor open(uint32_t root);
+    bool seek(Cursor& c, int64_t key);
+    bool next(Cursor& c);
+    std::string_view read_payload(const Cursor& c);
+private:
+    Pager& pager_;
+    std::vector<std::vector<std::pair<int64_t, std::string>>> mem_; // stub
+};
+
+} // namespace tinydb
+

--- a/include/tinydb/catalog.hpp
+++ b/include/tinydb/catalog.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+namespace tinydb {
+
+struct TableInfo {
+    std::string name;
+    uint32_t root{0};
+};
+
+class Catalog {
+public:
+    bool create_table(const std::string& name, uint32_t root);
+    const TableInfo* lookup(const std::string& name) const;
+private:
+    std::unordered_map<std::string, TableInfo> tables_;
+};
+
+} // namespace tinydb
+

--- a/include/tinydb/codegen.hpp
+++ b/include/tinydb/codegen.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <memory>
+#include <vector>
+#include "tinydb/parser.hpp"
+#include "tinydb/vm.hpp"
+#include "tinydb/catalog.hpp"
+
+namespace tinydb {
+
+std::vector<Instr> codegen(const ASTNode& ast, const Catalog& cat);
+
+} // namespace tinydb
+

--- a/include/tinydb/pager.hpp
+++ b/include/tinydb/pager.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include <array>
+#include <cstdint>
+#include <memory>
+
+namespace tinydb {
+
+struct Page {
+    uint32_t no{};
+    std::array<uint8_t, 4096> data{};
+    bool dirty{false};
+};
+
+class IStorage {
+public:
+    virtual ~IStorage() = default;
+    virtual void read(uint64_t off, void* buf, size_t n) = 0;
+    virtual void write(uint64_t off, const void* buf, size_t n) = 0;
+    virtual void sync() = 0;
+};
+
+class Pager {
+public:
+    explicit Pager(std::unique_ptr<IStorage> s);
+    Page& get(uint32_t pgno);
+    uint32_t alloc();
+    void mark_dirty(Page&);
+    void flush();
+private:
+    std::unique_ptr<IStorage> storage_;
+    Page dummy_; // stub
+};
+
+} // namespace tinydb
+

--- a/include/tinydb/parser.hpp
+++ b/include/tinydb/parser.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace tinydb {
+
+struct ASTNode { virtual ~ASTNode() = default; };
+struct ASTCreate : ASTNode { std::string table; std::vector<std::pair<std::string,std::string>> cols; };
+struct ASTInsert : ASTNode { std::string table; std::vector<std::string> values; };
+struct ASTSelect : ASTNode { std::string table; std::vector<std::string> cols; bool where_rowid=false; long long rowid=0; };
+
+std::unique_ptr<ASTNode> parse(const std::string& sql);
+
+} // namespace tinydb
+

--- a/include/tinydb/record.hpp
+++ b/include/tinydb/record.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace tinydb {
+
+enum class ColTag : uint8_t { INT = 0, TEXT = 1 };
+
+struct Value {
+    ColTag tag{ColTag::INT};
+    int64_t i{0};
+    std::string s{};
+};
+
+std::vector<uint8_t> encode_row(const std::vector<Value>& cols);
+std::vector<Value>   decode_row(const uint8_t* p, size_t n);
+
+} // namespace tinydb
+

--- a/include/tinydb/storage.hpp
+++ b/include/tinydb/storage.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+#include "tinydb/pager.hpp"
+
+namespace tinydb {
+
+class FileStorage : public IStorage {
+public:
+    explicit FileStorage(const std::string& path);
+    ~FileStorage() override;
+    void read(uint64_t off, void* buf, size_t n) override;
+    void write(uint64_t off, const void* buf, size_t n) override;
+    void sync() override;
+private:
+    std::string path_;
+    std::FILE* f_{nullptr};
+};
+
+} // namespace tinydb
+

--- a/include/tinydb/varint.hpp
+++ b/include/tinydb/varint.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+#include <utility>
+
+namespace tinydb {
+
+std::vector<uint8_t> encode_varint(uint64_t x);
+std::pair<uint64_t, size_t> decode_varint(const uint8_t* p, size_t n);
+
+} // namespace tinydb
+

--- a/include/tinydb/vm.hpp
+++ b/include/tinydb/vm.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace tinydb {
+
+enum class Op : uint8_t {
+    OpenRead, OpenWrite, Rewind, SeekGE, Column,
+    ResultRow, Next, Integer, Insert, Halt
+};
+
+struct Instr {
+    Op op;
+    int p1{0}, p2{0}, p3{0};
+    std::string p4;
+};
+
+class VM {
+public:
+    int run(const std::vector<Instr>& prog);
+};
+
+} // namespace tinydb
+

--- a/meson.build
+++ b/meson.build
@@ -1,17 +1,19 @@
-project('tinydb', 'cpp', version: '0.1.0', default_options: ['warning_level=3', 'cpp_std=c++20'])
+project('tinydb', 'cpp', version: '0.1.0', default_options: [
+  'warning_level=3',
+  'cpp_std=c++20'
+])
+
+add_project_arguments('-DTINYDB_PAGE_SIZE=4096', language: 'cpp')
+
+if get_option('sanitizers') and get_option('buildtype') == 'debug'
+  add_project_arguments(['-fsanitize=address,undefined'], language: 'cpp')
+  add_project_link_arguments(['-fsanitize=address,undefined'], language: 'cpp')
+endif
 
 inc = include_directories('include')
 
 subdir('src')
+subdir('cli')
+subdir('tests')
+subdir('tools')
 
-if get_option('build_cli')
-  subdir('cli')
-endif
-
-if get_option('build_tests')
-  subdir('tests')
-endif
-
-if get_option('build_tools')
-  subdir('tools')
-endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,2 @@
-option('build_cli', type: 'boolean', value: false, description: 'Build command line interface')
-option('build_tests', type: 'boolean', value: false, description: 'Build test suite')
-option('build_tools', type: 'boolean', value: false, description: 'Build developer tools')
+option('sanitizers', type: 'boolean', value: true, description: 'Enable ASAN/UBSAN in Debug')
+

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1,0 +1,3 @@
+#include "tinydb/ast.hpp"
+// empty on purpose
+

--- a/src/btree.cpp
+++ b/src/btree.cpp
@@ -1,0 +1,48 @@
+#include "tinydb/btree.hpp"
+#include <algorithm>
+
+namespace tinydb {
+
+BTree::BTree(Pager& p) : pager_(p) {
+    mem_.resize(1); // root 0 stub
+}
+
+uint32_t BTree::create_table() {
+    mem_.push_back({});
+    return static_cast<uint32_t>(mem_.size() - 1);
+}
+
+void BTree::insert(uint32_t root, Key k, std::string_view payload) {
+    if (root >= mem_.size()) mem_.resize(root + 1);
+    mem_[root].push_back({k.rowid, std::string(payload)});
+    std::sort(mem_[root].begin(), mem_[root].end(),
+              [](auto& a, auto& b){ return a.first < b.first; });
+}
+
+Cursor BTree::open(uint32_t root) {
+    return Cursor{root, 0};
+}
+
+bool BTree::seek(Cursor& c, int64_t key) {
+    auto& v = mem_[c.root];
+    auto it = std::lower_bound(v.begin(), v.end(), key,
+        [](auto& p, int64_t k){ return p.first < k; });
+    c.idx = static_cast<int>(it - v.begin());
+    return (it != v.end() && it->first == key);
+}
+
+bool BTree::next(Cursor& c) {
+    auto& v = mem_[c.root];
+    if (c.idx + 1 < static_cast<int>(v.size())) { ++c.idx; return true; }
+    return false;
+}
+
+std::string_view BTree::read_payload(const Cursor& c) {
+    auto& v = mem_[c.root];
+    if (c.idx >= 0 && c.idx < static_cast<int>(v.size())) return v[c.idx].second;
+    static std::string empty;
+    return empty;
+}
+
+} // namespace tinydb
+

--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -1,0 +1,16 @@
+#include "tinydb/catalog.hpp"
+
+namespace tinydb {
+
+bool Catalog::create_table(const std::string& name, uint32_t root) {
+    return tables_.emplace(name, TableInfo{name, root}).second;
+}
+
+const TableInfo* Catalog::lookup(const std::string& name) const {
+    auto it = tables_.find(name);
+    if (it == tables_.end()) return nullptr;
+    return &it->second;
+}
+
+} // namespace tinydb
+

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1,0 +1,14 @@
+#include "tinydb/codegen.hpp"
+#include <type_traits>
+
+namespace tinydb {
+
+std::vector<Instr> codegen(const ASTNode& ast, const Catalog&) {
+    std::vector<Instr> p;
+    // Minimal program just halts (stub)
+    p.push_back({Op::Halt, 0,0,0,{}});
+    return p;
+}
+
+} // namespace tinydb
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,15 +1,16 @@
-srcs = [
-  'pager.cpp',
-  'storage.cpp',
-  'varint.cpp',
-  'record.cpp',
-  'btree.cpp',
-  'catalog.cpp',
-  'vm.cpp',
-  'parser.cpp',
-  'codegen.cpp',
-  'ast.cpp',
-]
+tinydb_sources = files(
+  'pager.cpp', 'storage.cpp', 'varint.cpp', 'record.cpp',
+  'btree.cpp', 'catalog.cpp', 'vm.cpp', 'parser.cpp', 'codegen.cpp', 'ast.cpp'
+)
 
-libtinydb = static_library('tinydb', srcs, include_directories: inc)
-tinydb_dep = declare_dependency(link_with: libtinydb, include_directories: inc)
+tinydb_lib = static_library('tinydb',
+  sources: tinydb_sources,
+  include_directories: inc,
+  install: false
+)
+
+tinydb_dep = declare_dependency(
+  include_directories: inc,
+  link_with: tinydb_lib
+)
+

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -1,0 +1,20 @@
+#include "tinydb/pager.hpp"
+
+namespace tinydb {
+
+Pager::Pager(std::unique_ptr<IStorage> s) : storage_(std::move(s)) {}
+
+Page& Pager::get(uint32_t) {
+    return dummy_;
+}
+
+uint32_t Pager::alloc() { return 1; }
+
+void Pager::mark_dirty(Page& p) { p.dirty = true; }
+
+void Pager::flush() {
+    // stub
+}
+
+} // namespace tinydb
+

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,0 +1,33 @@
+#include "tinydb/parser.hpp"
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+#include <string>
+
+namespace tinydb {
+namespace {
+std::string upper(std::string s){ for (auto& c : s) c = static_cast<char>(std::toupper(c)); return s; }
+}
+
+std::unique_ptr<ASTNode> parse(const std::string& sql) {
+    auto S = upper(sql);
+    if (S.rfind("CREATE TABLE", 0) == 0) {
+        auto n = std::make_unique<ASTCreate>();
+        n->table = "t";
+        n->cols = {{"a","INT"},{"b","TEXT"}};
+        return n;
+    }
+    if (S.rfind("INSERT", 0) == 0) {
+        auto n = std::make_unique<ASTInsert>();
+        n->table = "t";
+        n->values = {"1","'x'"};
+        return n;
+    }
+    auto n = std::make_unique<ASTSelect>();
+    n->table = "t";
+    n->cols = {"a","b"};
+    return n;
+}
+
+} // namespace tinydb
+

--- a/src/record.cpp
+++ b/src/record.cpp
@@ -1,0 +1,47 @@
+#include "tinydb/record.hpp"
+#include "tinydb/varint.hpp"
+
+namespace tinydb {
+
+std::vector<uint8_t> encode_row(const std::vector<Value>& cols) {
+    std::vector<uint8_t> out;
+    auto ncols = encode_varint(cols.size());
+    out.insert(out.end(), ncols.begin(), ncols.end());
+    for (auto& v : cols) {
+        out.push_back(static_cast<uint8_t>(v.tag));
+        if (v.tag == ColTag::INT) {
+            auto enc = encode_varint(static_cast<uint64_t>(v.i));
+            out.insert(out.end(), enc.begin(), enc.end());
+        } else {
+            auto len = encode_varint(v.s.size());
+            out.insert(out.end(), len.begin(), len.end());
+            out.insert(out.end(), v.s.begin(), v.s.end());
+        }
+    }
+    return out;
+}
+
+std::vector<Value> decode_row(const uint8_t* p, size_t n) {
+    std::vector<Value> cols;
+    auto [cnt, used] = decode_varint(p, n);
+    size_t off = used;
+    for (size_t i = 0; i < cnt && off < n; ++i) {
+        Value v;
+        v.tag = static_cast<ColTag>(p[off++]);
+        if (v.tag == ColTag::INT) {
+            auto [ival, u2] = decode_varint(p + off, n - off);
+            v.i = static_cast<int64_t>(ival);
+            off += u2;
+        } else {
+            auto [len, u2] = decode_varint(p + off, n - off);
+            off += u2;
+            v.s.assign(reinterpret_cast<const char*>(p + off), static_cast<size_t>(len));
+            off += static_cast<size_t>(len);
+        }
+        cols.push_back(std::move(v));
+    }
+    return cols;
+}
+
+} // namespace tinydb
+

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -1,0 +1,30 @@
+#include "tinydb/storage.hpp"
+#include <stdexcept>
+
+namespace tinydb {
+
+FileStorage::FileStorage(const std::string& path) : path_(path) {
+    f_ = std::fopen(path.c_str(), "w+b");
+    if (!f_) throw std::runtime_error("open failed");
+}
+
+FileStorage::~FileStorage() {
+    if (f_) std::fclose(f_);
+}
+
+void FileStorage::read(uint64_t off, void* buf, size_t n) {
+    std::fseek(f_, static_cast<long>(off), SEEK_SET);
+    std::fread(buf, 1, n, f_);
+}
+
+void FileStorage::write(uint64_t off, const void* buf, size_t n) {
+    std::fseek(f_, static_cast<long>(off), SEEK_SET);
+    std::fwrite(buf, 1, n, f_);
+}
+
+void FileStorage::sync() {
+    std::fflush(f_);
+}
+
+} // namespace tinydb
+

--- a/src/varint.cpp
+++ b/src/varint.cpp
@@ -1,0 +1,29 @@
+#include "tinydb/varint.hpp"
+
+namespace tinydb {
+
+std::vector<uint8_t> encode_varint(uint64_t x) {
+    std::vector<uint8_t> out;
+    do {
+        uint8_t byte = x & 0x7F;
+        x >>= 7U;
+        if (x) byte |= 0x80;
+        out.push_back(byte);
+    } while (x);
+    return out;
+}
+
+std::pair<uint64_t,size_t> decode_varint(const uint8_t* p, size_t n) {
+    uint64_t v = 0;
+    size_t i = 0, shift = 0;
+    while (i < n) {
+        uint8_t b = p[i++];
+        v |= static_cast<uint64_t>(b & 0x7F) << shift;
+        if ((b & 0x80) == 0) break;
+        shift += 7;
+    }
+    return {v, i};
+}
+
+} // namespace tinydb
+

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -1,0 +1,12 @@
+#include "tinydb/vm.hpp"
+
+namespace tinydb {
+
+int VM::run(const std::vector<Instr>& prog) {
+    // Stub VM: just iterate and return 0
+    (void)prog;
+    return 0;
+}
+
+} // namespace tinydb
+

--- a/tests/btree_tests.cpp
+++ b/tests/btree_tests.cpp
@@ -1,0 +1,25 @@
+#include "tinydb/btree.hpp"
+#include <cassert>
+#include <memory>
+
+struct DummyStorage : tinydb::IStorage {
+    void read(uint64_t, void*, size_t) override {}
+    void write(uint64_t, const void*, size_t) override {}
+    void sync() override {}
+};
+
+int main() {
+    auto st = std::make_unique<DummyStorage>();
+    tinydb::Pager pager(std::move(st));
+    tinydb::BTree t(pager);
+    auto root = t.create_table();
+    t.insert(root, {2}, "b");
+    t.insert(root, {1}, "a");
+    auto c = t.open(root);
+    bool found = t.seek(c, 1);
+    assert(found);
+    auto v = t.read_payload(c);
+    assert(std::string(v) == "a");
+    return 0;
+}
+

--- a/tests/codegen_tests.cpp
+++ b/tests/codegen_tests.cpp
@@ -1,0 +1,14 @@
+#include "tinydb/parser.hpp"
+#include "tinydb/codegen.hpp"
+#include "tinydb/catalog.hpp"
+#include <cassert>
+
+int main() {
+    tinydb::Catalog cat;
+    cat.create_table("t", 1u);
+    auto ast = tinydb::parse("SELECT a,b FROM t");
+    auto prog = tinydb::codegen(*ast, cat);
+    (void)prog;
+    return 0;
+}
+

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -1,0 +1,16 @@
+#include "tinydb/parser.hpp"
+#include "tinydb/codegen.hpp"
+#include "tinydb/catalog.hpp"
+#include "tinydb/vm.hpp"
+#include <cassert>
+
+int main() {
+    tinydb::Catalog cat; cat.create_table("t", 1u);
+    auto ast = tinydb::parse("SELECT a,b FROM t");
+    auto prog = tinydb::codegen(*ast, cat);
+    tinydb::VM vm;
+    int rc = vm.run(prog);
+    assert(rc == 0);
+    return 0;
+}
+

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,20 +1,20 @@
-gtest_dep = dependency('gtest', main: true, required: false)
+test_srcs = [
+  'pager_tests.cpp',
+  'varint_tests.cpp',
+  'record_tests.cpp',
+  'btree_tests.cpp',
+  'vm_tests.cpp',
+  'parser_tests.cpp',
+  'codegen_tests.cpp',
+  'integration_tests.cpp'
+]
 
-if gtest_dep.found()
-  tests = [
-    'pager_tests.cpp',
-    'varint_tests.cpp',
-    'record_tests.cpp',
-    'btree_tests.cpp',
-    'vm_tests.cpp',
-    'parser_tests.cpp',
-    'codegen_tests.cpp',
-    'integration_tests.cpp',
-  ]
+foreach t : test_srcs
+  name = t.split('.')[0]
+  exe = executable('test_' + name, t,
+    include_directories: inc,
+    dependencies: tinydb_dep
+  )
+  test(name, exe)
+endforeach
 
-  foreach t : tests
-    name = t.split('.')[0]
-    exe = executable(name, t, dependencies: [tinydb_dep, gtest_dep])
-    test(name, exe)
-  endforeach
-endif

--- a/tests/pager_tests.cpp
+++ b/tests/pager_tests.cpp
@@ -1,0 +1,21 @@
+#include "tinydb/pager.hpp"
+#include <cassert>
+#include <memory>
+
+struct DummyStorage : tinydb::IStorage {
+    void read(uint64_t, void*, size_t) override {}
+    void write(uint64_t, const void*, size_t) override {}
+    void sync() override {}
+};
+
+int main() {
+    auto st = std::make_unique<DummyStorage>();
+    tinydb::Pager p(std::move(st));
+    auto& pg = p.get(1);
+    assert(pg.dirty == false);
+    p.mark_dirty(pg);
+    assert(pg.dirty == true);
+    p.flush();
+    return 0;
+}
+

--- a/tests/parser_tests.cpp
+++ b/tests/parser_tests.cpp
@@ -1,0 +1,12 @@
+#include "tinydb/parser.hpp"
+#include <cassert>
+#include <memory>
+
+int main() {
+    auto n1 = tinydb::parse("CREATE TABLE t(a INT, b TEXT)");
+    auto n2 = tinydb::parse("INSERT INTO t VALUES(1,'x')");
+    auto n3 = tinydb::parse("SELECT a,b FROM t");
+    assert(n1 && n2 && n3);
+    return 0;
+}
+

--- a/tests/record_tests.cpp
+++ b/tests/record_tests.cpp
@@ -1,0 +1,14 @@
+#include "tinydb/record.hpp"
+#include <cassert>
+
+int main() {
+    using tinydb::Value; using tinydb::ColTag;
+    std::vector<Value> row{{ColTag::INT, 42, {}}, {ColTag::TEXT, 0, "hello"}};
+    auto bytes = tinydb::encode_row(row);
+    auto out = tinydb::decode_row(bytes.data(), bytes.size());
+    assert(out.size() == 2);
+    assert(out[0].tag == ColTag::INT && out[0].i == 42);
+    assert(out[1].tag == ColTag::TEXT && out[1].s == "hello");
+    return 0;
+}
+

--- a/tests/varint_tests.cpp
+++ b/tests/varint_tests.cpp
@@ -1,0 +1,14 @@
+#include "tinydb/varint.hpp"
+#include <cassert>
+#include <vector>
+
+int main() {
+    for (uint64_t v : {0ull, 1ull, 127ull, 128ull, 300ull, (1ull<<32), (1ull<<40)}) {
+        auto enc = tinydb::encode_varint(v);
+        auto [dec, used] = tinydb::decode_varint(enc.data(), enc.size());
+        assert(used == enc.size());
+        assert(dec == v);
+    }
+    return 0;
+}
+

--- a/tests/vm_tests.cpp
+++ b/tests/vm_tests.cpp
@@ -1,0 +1,11 @@
+#include "tinydb/vm.hpp"
+#include <cassert>
+
+int main() {
+    tinydb::VM vm;
+    std::vector<tinydb::Instr> prog{{tinydb::Op::Halt,0,0,0,{}}};
+    int rc = vm.run(prog);
+    assert(rc == 0);
+    return 0;
+}
+

--- a/tools/dump_db.cpp
+++ b/tools/dump_db.cpp
@@ -1,0 +1,3 @@
+#include <cstdio>
+int main() { std::puts("dump_db (stub)"); return 0; }
+

--- a/tools/fuzz_parser.cpp
+++ b/tools/fuzz_parser.cpp
@@ -1,0 +1,3 @@
+#include <cstdio>
+int main() { std::puts("fuzz_parser (stub)"); return 0; }
+

--- a/tools/inspect_vm.cpp
+++ b/tools/inspect_vm.cpp
@@ -1,0 +1,3 @@
+#include <cstdio>
+int main() { std::puts("inspect_vm (stub)"); return 0; }
+

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,9 +1,14 @@
 tools = [
-  ['fuzz_parser', 'fuzz_parser.cpp'],
-  ['dump_db', 'dump_db.cpp'],
-  ['inspect_vm', 'inspect_vm.cpp'],
+  ['dump_db',      'dump_db.cpp'],
+  ['inspect_vm',   'inspect_vm.cpp'],
+  ['fuzz_parser',  'fuzz_parser.cpp']
 ]
 
-foreach t : tools
-  executable(t[0], t[1], dependencies: tinydb_dep)
+foreach tool : tools
+  executable(tool[0], tool[1],
+    include_directories: inc,
+    dependencies: tinydb_dep,
+    install: false
+  )
 endforeach
+


### PR DESCRIPTION
## Summary
- set up Meson-based build with sanitizers option and default page size
- add stub implementations for pager, storage, varint, record, btree, catalog, VM, parser, and codegen
- include CLI, developer tools, docs, and minimal tests

## Testing
- `meson setup build`
- `meson compile -C build`
- `meson test -C build --print-errorlogs`
- `./build/cli/tinydb | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b8ab5da4b48321b850c2cdc48593b0