### PR TITLE
Implement file-backed storage and pager

### DIFF
--- a/include/tinydb/pager.hpp
+++ b/include/tinydb/pager.hpp
@@ -2,21 +2,17 @@
 #include <array>
 #include <cstdint>
 #include <memory>
+#include <unordered_map>
+#include "tinydb/storage.hpp"
 
 namespace tinydb {
 
+constexpr uint32_t PAGE_SIZE = 4096;
+
 struct Page {
     uint32_t no{};
-    std::array<uint8_t, 4096> data{};
+    std::array<uint8_t, PAGE_SIZE> data{};
     bool dirty{false};
-};
-
-class IStorage {
-public:
-    virtual ~IStorage() = default;
-    virtual void read(uint64_t off, void* buf, size_t n) = 0;
-    virtual void write(uint64_t off, const void* buf, size_t n) = 0;
-    virtual void sync() = 0;
 };
 
 class Pager {
@@ -28,7 +24,8 @@ public:
     void flush();
 private:
     std::unique_ptr<IStorage> storage_;
-    Page dummy_; // stub
+    std::unordered_map<uint32_t, std::unique_ptr<Page>> cache_;
+    uint32_t next_pgno_{1};
 };
 
 } // namespace tinydb

--- a/include/tinydb/storage.hpp
+++ b/include/tinydb/storage.hpp
@@ -1,11 +1,18 @@
+// Storage interface and file-backed implementation
 #pragma once
 #include <cstdint>
 #include <cstdio>
 #include <string>
-#include <vector>
-#include "tinydb/pager.hpp"
 
 namespace tinydb {
+
+class IStorage {
+public:
+    virtual ~IStorage() = default;
+    virtual void read(uint64_t off, void* buf, size_t n) = 0;
+    virtual void write(uint64_t off, const void* buf, size_t n) = 0;
+    virtual void sync() = 0;
+};
 
 class FileStorage : public IStorage {
 public:

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -4,16 +4,41 @@ namespace tinydb {
 
 Pager::Pager(std::unique_ptr<IStorage> s) : storage_(std::move(s)) {}
 
-Page& Pager::get(uint32_t) {
-    return dummy_;
+Page& Pager::get(uint32_t pgno) {
+    auto it = cache_.find(pgno);
+    if (it == cache_.end()) {
+        auto page = std::make_unique<Page>();
+        page->no = pgno;
+        page->data.fill(0);
+        storage_->read(static_cast<uint64_t>(pgno - 1) * PAGE_SIZE,
+                       page->data.data(), PAGE_SIZE);
+        it = cache_.emplace(pgno, std::move(page)).first;
+    }
+    if (pgno >= next_pgno_) next_pgno_ = pgno + 1;
+    return *it->second;
 }
 
-uint32_t Pager::alloc() { return 1; }
+uint32_t Pager::alloc() {
+    uint32_t pgno = next_pgno_++;
+    auto page = std::make_unique<Page>();
+    page->no = pgno;
+    page->data.fill(0);
+    cache_[pgno] = std::move(page);
+    return pgno;
+}
 
 void Pager::mark_dirty(Page& p) { p.dirty = true; }
 
 void Pager::flush() {
-    // stub
+    for (auto& kv : cache_) {
+        Page& p = *kv.second;
+        if (p.dirty) {
+            storage_->write(static_cast<uint64_t>(p.no - 1) * PAGE_SIZE,
+                             p.data.data(), PAGE_SIZE);
+            p.dirty = false;
+        }
+    }
+    storage_->sync();
 }
 
 } // namespace tinydb

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -1,10 +1,12 @@
 #include "tinydb/storage.hpp"
+#include <cstring>
 #include <stdexcept>
 
 namespace tinydb {
 
 FileStorage::FileStorage(const std::string& path) : path_(path) {
-    f_ = std::fopen(path.c_str(), "w+b");
+    f_ = std::fopen(path.c_str(), "r+b");
+    if (!f_) f_ = std::fopen(path.c_str(), "w+b");
     if (!f_) throw std::runtime_error("open failed");
 }
 
@@ -13,6 +15,7 @@ FileStorage::~FileStorage() {
 }
 
 void FileStorage::read(uint64_t off, void* buf, size_t n) {
+    std::memset(buf, 0, n);
     std::fseek(f_, static_cast<long>(off), SEEK_SET);
     std::fread(buf, 1, n, f_);
 }


### PR DESCRIPTION
## Summary
- add `IStorage` interface and `FileStorage` implementation with safe reopen and zero-filled reads
- implement pager with page cache, allocation, dirty tracking, and flush sync
- test round-trip write/read via pager to verify data persists after reopen

## Testing
- `meson test -C build pager_tests`
- `meson test -C build`


------
https://chatgpt.com/codex/tasks/task_e_68b8af14e1348321b950e7afe702801c