### PR TITLE
Implement varint/record property tests and leaf-only B-tree

### DIFF
--- a/include/tinydb/btree.hpp
+++ b/include/tinydb/btree.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <cstdint>
+#include <string>
 #include <string_view>
-#include <vector>
 #include "tinydb/pager.hpp"
 
 namespace tinydb {
@@ -11,6 +11,7 @@ struct Key { int64_t rowid{0}; };
 class Cursor {
 public:
     uint32_t root{0};
+    uint32_t pgno{0};
     int idx{0};
 };
 
@@ -23,9 +24,11 @@ public:
     bool seek(Cursor& c, int64_t key);
     bool next(Cursor& c);
     std::string_view read_payload(const Cursor& c);
+    int64_t key(const Cursor& c);
+    bool check(uint32_t root);
 private:
     Pager& pager_;
-    std::vector<std::vector<std::pair<int64_t, std::string>>> mem_; // stub
+    std::string tmp_;
 };
 
 } // namespace tinydb

--- a/src/btree.cpp
+++ b/src/btree.cpp
@@ -1,47 +1,250 @@
 #include "tinydb/btree.hpp"
 #include <algorithm>
+#include <cstring>
+#include <limits>
+#include <vector>
 
 namespace tinydb {
 
-BTree::BTree(Pager& p) : pager_(p) {
-    mem_.resize(1); // root 0 stub
+namespace {
+
+static uint16_t read16(const uint8_t* p) {
+    return static_cast<uint16_t>(p[0]) |
+           static_cast<uint16_t>(p[1]) << 8;
 }
 
+static void write16(uint8_t* p, uint16_t v) {
+    p[0] = static_cast<uint8_t>(v & 0xFF);
+    p[1] = static_cast<uint8_t>((v >> 8) & 0xFF);
+}
+
+static uint32_t read32(const uint8_t* p) {
+    return static_cast<uint32_t>(p[0]) |
+           static_cast<uint32_t>(p[1]) << 8 |
+           static_cast<uint32_t>(p[2]) << 16 |
+           static_cast<uint32_t>(p[3]) << 24;
+}
+
+static void write32(uint8_t* p, uint32_t v) {
+    p[0] = static_cast<uint8_t>(v & 0xFF);
+    p[1] = static_cast<uint8_t>((v >> 8) & 0xFF);
+    p[2] = static_cast<uint8_t>((v >> 16) & 0xFF);
+    p[3] = static_cast<uint8_t>((v >> 24) & 0xFF);
+}
+
+static int64_t read64(const uint8_t* p) {
+    uint64_t v = 0;
+    for (int i = 0; i < 8; ++i) v |= uint64_t(p[i]) << (8 * i);
+    return static_cast<int64_t>(v);
+}
+
+static void write64(uint8_t* p, int64_t v) {
+    uint64_t u = static_cast<uint64_t>(v);
+    for (int i = 0; i < 8; ++i) p[i] = static_cast<uint8_t>((u >> (8 * i)) & 0xFF);
+}
+
+struct LeafData {
+    uint32_t next{0};
+    std::vector<std::pair<int64_t, std::string_view>> cells;
+};
+
+static LeafData load_leaf(Page& page) {
+    LeafData leaf;
+    const uint8_t* d = page.data.data();
+    uint16_t ncell = read16(d);
+    leaf.next = read32(d + 2);
+    leaf.cells.reserve(ncell);
+    size_t off = 6;
+    for (uint16_t i = 0; i < ncell; ++i) {
+        int64_t key = read64(d + off);
+        uint16_t len = read16(d + off + 8);
+        leaf.cells.emplace_back(key,
+            std::string_view(reinterpret_cast<const char*>(d + off + 10), len));
+        off += 10 + len;
+    }
+    return leaf;
+}
+
+static void store_leaf(Page& page, const LeafData& leaf) {
+    uint8_t* d = page.data.data();
+    write16(d, static_cast<uint16_t>(leaf.cells.size()));
+    write32(d + 2, leaf.next);
+    size_t off = 6;
+    for (auto& cell : leaf.cells) {
+        write64(d + off, cell.first);
+        uint16_t len = static_cast<uint16_t>(cell.second.size());
+        write16(d + off + 8, len);
+        std::memcpy(d + off + 10, cell.second.data(), len);
+        off += 10 + len;
+    }
+    if (off < PAGE_SIZE) std::memset(d + off, 0, PAGE_SIZE - off);
+}
+
+static size_t leaf_size(const LeafData& leaf) {
+    size_t n = 6;
+    for (auto& cell : leaf.cells) n += 10 + cell.second.size();
+    return n;
+}
+
+static int64_t last_key(Page& page, uint32_t& next) {
+    const uint8_t* d = page.data.data();
+    uint16_t ncell = read16(d);
+    next = read32(d + 2);
+    if (ncell == 0) return std::numeric_limits<int64_t>::min();
+    size_t off = 6;
+    for (uint16_t i = 0; i < ncell - 1; ++i) {
+        uint16_t len = read16(d + off + 8);
+        off += 10 + len;
+    }
+    return read64(d + off);
+}
+
+} // namespace
+
+BTree::BTree(Pager& p) : pager_(p) {}
+
 uint32_t BTree::create_table() {
-    mem_.push_back({});
-    return static_cast<uint32_t>(mem_.size() - 1);
+    uint32_t pgno = pager_.alloc();
+    Page& page = pager_.get(pgno);
+    uint8_t* d = page.data.data();
+    write16(d, 0);
+    write32(d + 2, 0);
+    pager_.mark_dirty(page);
+    return pgno;
 }
 
 void BTree::insert(uint32_t root, Key k, std::string_view payload) {
-    if (root >= mem_.size()) mem_.resize(root + 1);
-    mem_[root].push_back({k.rowid, std::string(payload)});
-    std::sort(mem_[root].begin(), mem_[root].end(),
-              [](auto& a, auto& b){ return a.first < b.first; });
+    uint32_t pgno = root;
+    while (true) {
+        Page& page = pager_.get(pgno);
+        uint32_t next_pg;
+        int64_t last = last_key(page, next_pg);
+        if (k.rowid > last && next_pg != 0) {
+            pgno = next_pg;
+            continue;
+        }
+        LeafData leaf = load_leaf(page);
+        auto it = std::lower_bound(leaf.cells.begin(), leaf.cells.end(), k.rowid,
+            [](const auto& a, int64_t key){ return a.first < key; });
+        if (it != leaf.cells.end() && it->first == k.rowid) {
+            it->second = payload;
+        } else {
+            leaf.cells.insert(it, {k.rowid, payload});
+        }
+        if (leaf_size(leaf) <= PAGE_SIZE) {
+            store_leaf(page, leaf);
+            pager_.mark_dirty(page);
+        } else {
+            LeafData newleaf;
+            size_t sz = 0;
+            size_t i = 0;
+            for (; i < leaf.cells.size(); ++i) {
+                size_t cell_sz = 10 + leaf.cells[i].second.size();
+                if (sz + cell_sz > PAGE_SIZE / 2 && i > 0) break;
+                sz += cell_sz;
+            }
+            newleaf.cells.assign(leaf.cells.begin() + i, leaf.cells.end());
+            leaf.cells.erase(leaf.cells.begin() + i, leaf.cells.end());
+            uint32_t new_pgno = pager_.alloc();
+            newleaf.next = leaf.next;
+            leaf.next = new_pgno;
+            Page& new_page = pager_.get(new_pgno);
+            store_leaf(page, leaf);
+            pager_.mark_dirty(page);
+            store_leaf(new_page, newleaf);
+            pager_.mark_dirty(new_page);
+        }
+        break;
+    }
 }
 
-Cursor BTree::open(uint32_t root) {
-    return Cursor{root, 0};
-}
+Cursor BTree::open(uint32_t root) { return Cursor{root, root, 0}; }
 
 bool BTree::seek(Cursor& c, int64_t key) {
-    auto& v = mem_[c.root];
-    auto it = std::lower_bound(v.begin(), v.end(), key,
-        [](auto& p, int64_t k){ return p.first < k; });
-    c.idx = static_cast<int>(it - v.begin());
-    return (it != v.end() && it->first == key);
+    uint32_t pgno = c.root;
+    while (true) {
+        Page& page = pager_.get(pgno);
+        const uint8_t* d = page.data.data();
+        uint16_t ncell = read16(d);
+        uint32_t next = read32(d + 2);
+        size_t off = 6;
+        for (uint16_t i = 0; i < ncell; ++i) {
+            int64_t k = read64(d + off);
+            if (k >= key) {
+                c.pgno = pgno;
+                c.idx = i;
+                return (k == key);
+            }
+            uint16_t len = read16(d + off + 8);
+            off += 10 + len;
+        }
+        if (next == 0) {
+            c.pgno = pgno;
+            c.idx = ncell;
+            return false;
+        }
+        pgno = next;
+    }
 }
 
 bool BTree::next(Cursor& c) {
-    auto& v = mem_[c.root];
-    if (c.idx + 1 < static_cast<int>(v.size())) { ++c.idx; return true; }
-    return false;
+    Page& page = pager_.get(c.pgno);
+    const uint8_t* d = page.data.data();
+    uint16_t ncell = read16(d);
+    if (c.idx + 1 < ncell) { ++c.idx; return true; }
+    uint32_t next = read32(d + 2);
+    if (next == 0) return false;
+    c.pgno = next;
+    c.idx = 0;
+    Page& np = pager_.get(c.pgno);
+    return read16(np.data.data()) > 0;
 }
 
 std::string_view BTree::read_payload(const Cursor& c) {
-    auto& v = mem_[c.root];
-    if (c.idx >= 0 && c.idx < static_cast<int>(v.size())) return v[c.idx].second;
-    static std::string empty;
-    return empty;
+    Page& page = pager_.get(c.pgno);
+    const uint8_t* d = page.data.data();
+    uint16_t ncell = read16(d);
+    size_t off = 6;
+    for (uint16_t i = 0; i < ncell; ++i) {
+        uint16_t len = read16(d + off + 8);
+        if (static_cast<int>(i) == c.idx) {
+            tmp_.assign(reinterpret_cast<const char*>(d + off + 10), len);
+            return tmp_;
+        }
+        off += 10 + len;
+    }
+    tmp_.clear();
+    return tmp_;
+}
+
+int64_t BTree::key(const Cursor& c) {
+    Page& page = pager_.get(c.pgno);
+    const uint8_t* d = page.data.data();
+    uint16_t ncell = read16(d);
+    size_t off = 6;
+    for (uint16_t i = 0; i < ncell; ++i) {
+        int64_t k = read64(d + off);
+        uint16_t len = read16(d + off + 8);
+        if (static_cast<int>(i) == c.idx) return k;
+        off += 10 + len;
+    }
+    return 0;
+}
+
+bool BTree::check(uint32_t root) {
+    uint32_t pgno = root;
+    int64_t prev = std::numeric_limits<int64_t>::min();
+    while (pgno != 0) {
+        Page& page = pager_.get(pgno);
+        LeafData leaf = load_leaf(page);
+        if (leaf_size(leaf) > PAGE_SIZE) return false;
+        for (auto& cell : leaf.cells) {
+            if (cell.first < prev) return false;
+            prev = cell.first;
+        }
+        pgno = leaf.next;
+    }
+    return true;
 }
 
 } // namespace tinydb

--- a/tests/btree_tests.cpp
+++ b/tests/btree_tests.cpp
@@ -1,25 +1,53 @@
 #include "tinydb/btree.hpp"
+#include "tinydb/storage.hpp"
+#include <algorithm>
 #include <cassert>
 #include <memory>
-
-struct DummyStorage : tinydb::IStorage {
-    void read(uint64_t, void*, size_t) override {}
-    void write(uint64_t, const void*, size_t) override {}
-    void sync() override {}
-};
+#include <random>
+#include <string>
+#include <vector>
 
 int main() {
-    auto st = std::make_unique<DummyStorage>();
-    tinydb::Pager pager(std::move(st));
-    tinydb::BTree t(pager);
-    auto root = t.create_table();
-    t.insert(root, {2}, "b");
-    t.insert(root, {1}, "a");
-    auto c = t.open(root);
-    bool found = t.seek(c, 1);
-    assert(found);
-    auto v = t.read_payload(c);
-    assert(std::string(v) == "a");
+    const char* path = "btree_test.db";
+    std::vector<int64_t> keys;
+    uint32_t root;
+    {
+        auto st = std::make_unique<tinydb::FileStorage>(path);
+        tinydb::Pager pager(std::move(st));
+        tinydb::BTree t(pager);
+        root = t.create_table();
+        std::mt19937_64 rng(123);
+        for (int i = 0; i < 1000; ++i) {
+            int64_t k = static_cast<int64_t>(rng());
+            keys.push_back(k);
+            t.insert(root, {k}, "");
+        }
+        assert(t.check(root));
+        std::sort(keys.begin(), keys.end());
+        auto c = t.open(root);
+        t.seek(c, keys.front());
+        for (size_t i = 0; i < keys.size(); ++i) {
+            assert(t.key(c) == keys[i]);
+            if (i + 1 < keys.size()) assert(t.next(c));
+            else assert(!t.next(c));
+        }
+        pager.flush();
+    }
+
+    std::sort(keys.begin(), keys.end());
+    {
+        auto st = std::make_unique<tinydb::FileStorage>(path);
+        tinydb::Pager pager(std::move(st));
+        tinydb::BTree t(pager);
+        assert(t.check(root));
+        auto c = t.open(root);
+        t.seek(c, keys.front());
+        for (size_t i = 0; i < keys.size(); ++i) {
+            assert(t.key(c) == keys[i]);
+            if (i + 1 < keys.size()) assert(t.next(c));
+            else assert(!t.next(c));
+        }
+    }
     return 0;
 }
 

--- a/tests/record_tests.cpp
+++ b/tests/record_tests.cpp
@@ -1,14 +1,42 @@
 #include "tinydb/record.hpp"
 #include <cassert>
+#include <limits>
+#include <random>
 
 int main() {
     using tinydb::Value; using tinydb::ColTag;
-    std::vector<Value> row{{ColTag::INT, 42, {}}, {ColTag::TEXT, 0, "hello"}};
-    auto bytes = tinydb::encode_row(row);
-    auto out = tinydb::decode_row(bytes.data(), bytes.size());
-    assert(out.size() == 2);
-    assert(out[0].tag == ColTag::INT && out[0].i == 42);
-    assert(out[1].tag == ColTag::TEXT && out[1].s == "hello");
+
+    // random round-trip property
+    std::mt19937_64 rng(123);
+    std::uniform_int_distribution<int64_t> dist_i(std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max());
+    std::uniform_int_distribution<int> dist_len(0, 1000);
+    for (int t = 0; t < 100; ++t) {
+        std::vector<Value> row;
+        row.push_back(Value{ColTag::INT, dist_i(rng), {}});
+        std::string s(dist_len(rng), 'x');
+        row.push_back(Value{ColTag::TEXT, 0, s});
+        auto bytes = tinydb::encode_row(row);
+        auto out = tinydb::decode_row(bytes.data(), bytes.size());
+        assert(out.size() == row.size());
+        assert(out[0].tag == ColTag::INT && out[0].i == row[0].i);
+        assert(out[1].tag == ColTag::TEXT && out[1].s == row[1].s);
+    }
+
+    // extremes
+    std::string big(100000, 'y');
+    std::vector<Value> row2{
+        {ColTag::INT, 0, {}},
+        {ColTag::INT, -1, {}},
+        {ColTag::INT, std::numeric_limits<int64_t>::max(), {}},
+        {ColTag::TEXT, 0, big}
+    };
+    auto bytes2 = tinydb::encode_row(row2);
+    auto out2 = tinydb::decode_row(bytes2.data(), bytes2.size());
+    assert(out2.size() == row2.size());
+    assert(out2[0].i == 0);
+    assert(out2[1].i == -1);
+    assert(out2[2].i == std::numeric_limits<int64_t>::max());
+    assert(out2[3].s == big);
     return 0;
 }
 

--- a/tests/varint_tests.cpp
+++ b/tests/varint_tests.cpp
@@ -1,9 +1,19 @@
 #include "tinydb/varint.hpp"
 #include <cassert>
-#include <vector>
+#include <random>
 
 int main() {
-    for (uint64_t v : {0ull, 1ull, 127ull, 128ull, 300ull, (1ull<<32), (1ull<<40)}) {
+    // random round-trip property
+    std::mt19937_64 rng(123);
+    for (int i = 0; i < 1000; ++i) {
+        uint64_t v = rng();
+        auto enc = tinydb::encode_varint(v);
+        auto [dec, used] = tinydb::decode_varint(enc.data(), enc.size());
+        assert(used == enc.size());
+        assert(dec == v);
+    }
+    // extremes
+    for (uint64_t v : {0ull, (1ull<<63) - 1, ~0ull}) {
         auto enc = tinydb::encode_varint(v);
         auto [dec, used] = tinydb::decode_varint(enc.data(), enc.size());
         assert(used == enc.size());


### PR DESCRIPTION
## Summary
- add round-trip property tests for varint and record codecs, covering random values and extremes
- implement persistent leaf-only B-tree with insert/seek/scan and invariant checking helper
- add B-tree test for random inserts and persistence

## Testing
- `meson test -C build`

------
https://chatgpt.com/codex/tasks/task_e_68b8b1695e7083218c7eaad741ed02cd