### PR TITLE
Add VM, parser, codegen, and CLI integration

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -1,8 +1,65 @@
+#include "tinydb/parser.hpp"
+#include "tinydb/codegen.hpp"
+#include "tinydb/catalog.hpp"
+#include "tinydb/vm.hpp"
+#include "tinydb/storage.hpp"
+#include "tinydb/pager.hpp"
+#include "tinydb/btree.hpp"
+#include <cctype>
 #include <iostream>
+#include <memory>
+#include <string>
 
 int main() {
-    std::cout << "tinydb CLI (stub)\n";
-    std::cout << "Type SQL or Ctrl-D to exit.\n";
+    using namespace tinydb;
+    std::unique_ptr<Pager> pager;
+    std::unique_ptr<BTree> btree;
+    std::unique_ptr<Catalog> catalog;
+    VM vm;
+    std::string line;
+    std::cout << "tinydb CLI\n";
+    while (std::cout << "tinydb> " && std::getline(std::cin, line)) {
+        if (line.empty()) continue;
+        if (line[0] == '.') {
+            if (line.rfind(".open", 0) == 0) {
+                std::string path = line.substr(5);
+                while (!path.empty() && std::isspace(static_cast<unsigned char>(path.front()))) path.erase(path.begin());
+                pager = std::make_unique<Pager>(std::make_unique<FileStorage>(path));
+                btree = std::make_unique<BTree>(*pager);
+                catalog = std::make_unique<Catalog>(*pager, *btree);
+                vm.set_env(*btree, *catalog);
+            } else if (line == ".schema") {
+                if (!catalog) { std::cout << "no db\n"; continue; }
+                for (auto& kv : catalog->tables()) {
+                    std::cout << kv.second.name << "\n";
+                }
+            } else {
+                std::cout << "unknown command\n";
+            }
+            continue;
+        }
+        if (!catalog) { std::cout << "no database open\n"; continue; }
+        auto ast = parse(line);
+        if (!ast) { std::cout << "parse error\n"; continue; }
+        if (auto c = dynamic_cast<ASTCreate*>(ast.get())) {
+            catalog->create_table(c->table);
+            std::cout << "ok\n";
+            continue;
+        }
+        auto prog = codegen(*ast, *catalog);
+        vm.run(prog);
+        if (dynamic_cast<ASTSelect*>(ast.get())) {
+            for (auto& row : vm.results()) {
+                for (size_t i = 0; i < row.size(); ++i) {
+                    if (i) std::cout << '|';
+                    if (row[i].tag == ColTag::INT) std::cout << row[i].i;
+                    else std::cout << row[i].s;
+                }
+                std::cout << "\n";
+            }
+        }
+    }
+    if (pager) pager->flush();
     return 0;
 }
 

--- a/include/tinydb/catalog.hpp
+++ b/include/tinydb/catalog.hpp
@@ -20,6 +20,7 @@ public:
     bool create_table(const std::string& name, uint32_t root);
     uint32_t create_table(const std::string& name);
     const TableInfo* lookup(const std::string& name) const;
+    const std::unordered_map<std::string, TableInfo>& tables() const { return tables_; }
 private:
     Pager* pager_{nullptr};
     BTree* btree_{nullptr};

--- a/include/tinydb/vm.hpp
+++ b/include/tinydb/vm.hpp
@@ -3,6 +3,9 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include "tinydb/btree.hpp"
+#include "tinydb/catalog.hpp"
+#include "tinydb/record.hpp"
 
 namespace tinydb {
 
@@ -19,7 +22,19 @@ struct Instr {
 
 class VM {
 public:
+    VM() = default;
+    VM(BTree& bt, Catalog& cat) : btree_(&bt), catalog_(&cat) {}
+    void set_env(BTree& bt, Catalog& cat) { btree_ = &bt; catalog_ = &cat; }
     int run(const std::vector<Instr>& prog);
+    const std::vector<std::vector<Value>>& results() const { return results_; }
+private:
+    BTree* btree_{nullptr};
+    Catalog* catalog_{nullptr};
+    std::vector<Cursor> cursors_;
+    std::vector<Value> regs_;
+    std::vector<std::vector<Value>> results_;
+    size_t last_row_cols_{0};
+    int64_t next_rowid_{1};
 };
 
 } // namespace tinydb

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1,12 +1,59 @@
 #include "tinydb/codegen.hpp"
+#include "tinydb/record.hpp"
 #include <type_traits>
 
 namespace tinydb {
+namespace {
+Value parse_value(const std::string& s) {
+    Value v;
+    if (!s.empty() && s.front() == '\'' && s.back() == '\'') {
+        v.tag = ColTag::TEXT;
+        v.s = s.substr(1, s.size() - 2);
+    } else {
+        v.tag = ColTag::INT;
+        v.i = std::stoll(s);
+    }
+    return v;
+}
+}
 
-std::vector<Instr> codegen(const ASTNode& ast, const Catalog&) {
+std::vector<Instr> codegen(const ASTNode& ast, const Catalog& cat) {
     std::vector<Instr> p;
-    // Minimal program just halts (stub)
-    p.push_back({Op::Halt, 0,0,0,{}});
+    if (auto ins = dynamic_cast<const ASTInsert*>(&ast)) {
+        const TableInfo* ti = cat.lookup(ins->table);
+        if (!ti) { p.push_back({Op::Halt,0,0,0,{}}); return p; }
+        std::vector<Value> vals;
+        for (auto& s : ins->values) vals.push_back(parse_value(s));
+        auto row = encode_row(vals);
+        p.push_back({Op::Insert, static_cast<int>(ti->root),0,0,
+                     std::string(reinterpret_cast<const char*>(row.data()), row.size())});
+        p.push_back({Op::Halt,0,0,0,{}});
+        return p;
+    } else if (auto sel = dynamic_cast<const ASTSelect*>(&ast)) {
+        const TableInfo* ti = cat.lookup(sel->table);
+        if (!ti) { p.push_back({Op::Halt,0,0,0,{}}); return p; }
+        p.push_back({Op::OpenRead,0,static_cast<int>(ti->root),0,{}}); // 0
+        if (sel->where_rowid) {
+            p.push_back({Op::Integer, static_cast<int>(sel->rowid),0,0,{}}); //1
+            p.push_back({Op::SeekGE,0,0,0,{}}); //2 fixup
+            p.push_back({Op::Column,0,-1,0,{}}); //3
+            int ncols = (sel->cols.size()==1 && sel->cols[0]=="*") ? 0 : static_cast<int>(sel->cols.size());
+            p.push_back({Op::ResultRow,0,ncols,0,{}}); //4
+            p.push_back({Op::Halt,0,0,0,{}}); //5
+            p[2].p2 = static_cast<int>(p.size()-1);
+        } else {
+            p.push_back({Op::Rewind,0,0,0,{}}); //1 fixup
+            p.push_back({Op::Column,0,-1,0,{}}); //2 loop start
+            int ncols = (sel->cols.size()==1 && sel->cols[0]=="*") ? 0 : static_cast<int>(sel->cols.size());
+            p.push_back({Op::ResultRow,0,ncols,0,{}}); //3
+            p.push_back({Op::Next,0,0,0,{}}); //4 fixup
+            p.push_back({Op::Halt,0,0,0,{}}); //5
+            p[1].p2 = static_cast<int>(p.size()-1);
+            p[4].p2 = 2; // loop back to Column
+        }
+        return p;
+    }
+    p.push_back({Op::Halt,0,0,0,{}});
     return p;
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,32 +1,130 @@
 #include "tinydb/parser.hpp"
-#include <algorithm>
 #include <cctype>
-#include <sstream>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace tinydb {
 namespace {
-std::string upper(std::string s){ for (auto& c : s) c = static_cast<char>(std::toupper(c)); return s; }
-}
+class Parser {
+public:
+    explicit Parser(const std::string& s) : sql(s), pos(0) {}
+    void skip_ws() {
+        while (pos < sql.size() && std::isspace(static_cast<unsigned char>(sql[pos]))) ++pos;
+    }
+    bool match_kw(const std::string& kw) {
+        skip_ws();
+        size_t len = kw.size();
+        if (pos + len > sql.size()) return false;
+        for (size_t i = 0; i < len; ++i) {
+            if (std::toupper(static_cast<unsigned char>(sql[pos + i])) != kw[i]) return false;
+        }
+        pos += len;
+        return true;
+    }
+    bool consume(char c) {
+        skip_ws();
+        if (pos < sql.size() && sql[pos] == c) { ++pos; return true; }
+        return false;
+    }
+    std::string parse_ident() {
+        skip_ws();
+        size_t start = pos;
+        while (pos < sql.size() && (std::isalnum(static_cast<unsigned char>(sql[pos])) || sql[pos]=='_')) ++pos;
+        return sql.substr(start, pos-start);
+    }
+    std::string parse_string() {
+        skip_ws();
+        if (pos >= sql.size() || sql[pos] != '\'') return {};
+        size_t start = ++pos;
+        while (pos < sql.size() && sql[pos] != '\'') ++pos;
+        std::string s = sql.substr(start, pos-start);
+        if (pos < sql.size()) ++pos; // consume closing quote
+        return "'" + s + "'"; // keep quotes as in AST
+    }
+    std::string parse_number() {
+        skip_ws();
+        size_t start = pos;
+        while (pos < sql.size() && std::isdigit(static_cast<unsigned char>(sql[pos]))) ++pos;
+        return sql.substr(start, pos-start);
+    }
+    bool eof() {
+        skip_ws();
+        return pos >= sql.size();
+    }
+    const std::string& sql;
+    size_t pos;
+};
+
+} // namespace
 
 std::unique_ptr<ASTNode> parse(const std::string& sql) {
-    auto S = upper(sql);
-    if (S.rfind("CREATE TABLE", 0) == 0) {
+    Parser p(sql);
+    if (p.match_kw("CREATE") && p.match_kw("TABLE")) {
         auto n = std::make_unique<ASTCreate>();
-        n->table = "t";
-        n->cols = {{"a","INT"},{"b","TEXT"}};
+        n->table = p.parse_ident();
+        if (!p.consume('(')) return nullptr;
+        while (true) {
+            std::string col = p.parse_ident();
+            if (col.empty()) return nullptr;
+            std::string type = p.parse_ident();
+            if (type.empty()) return nullptr;
+            n->cols.emplace_back(col, type);
+            if (p.consume(')')) break;
+            if (!p.consume(',')) return nullptr;
+        }
+        if (!p.eof()) return nullptr;
         return n;
     }
-    if (S.rfind("INSERT", 0) == 0) {
+    p.pos = 0; // reset
+    if (p.match_kw("INSERT") && p.match_kw("INTO")) {
         auto n = std::make_unique<ASTInsert>();
-        n->table = "t";
-        n->values = {"1","'x'"};
+        n->table = p.parse_ident();
+        if (!p.match_kw("VALUES")) return nullptr;
+        if (!p.consume('(')) return nullptr;
+        while (true) {
+            p.skip_ws();
+            std::string val;
+            if (p.pos < p.sql.size() && p.sql[p.pos] == '\'') val = p.parse_string();
+            else val = p.parse_number();
+            if (val.empty()) return nullptr;
+            n->values.push_back(val);
+            if (p.consume(')')) break;
+            if (!p.consume(',')) return nullptr;
+        }
+        if (!p.eof()) return nullptr;
         return n;
     }
-    auto n = std::make_unique<ASTSelect>();
-    n->table = "t";
-    n->cols = {"a","b"};
-    return n;
+    p.pos = 0;
+    if (p.match_kw("SELECT")) {
+        auto n = std::make_unique<ASTSelect>();
+        if (p.consume('*')) {
+            n->cols.push_back("*");
+        } else {
+            std::string col = p.parse_ident();
+            if (col.empty()) return nullptr;
+            n->cols.push_back(col);
+            while (p.consume(',')) {
+                std::string c2 = p.parse_ident();
+                if (c2.empty()) return nullptr;
+                n->cols.push_back(c2);
+            }
+        }
+        if (!p.match_kw("FROM")) return nullptr;
+        n->table = p.parse_ident();
+        if (n->table.empty()) return nullptr;
+        if (p.match_kw("WHERE")) {
+            if (!p.match_kw("ROWID")) return nullptr;
+            if (!p.consume('=')) return nullptr;
+            std::string num = p.parse_number();
+            if (num.empty()) return nullptr;
+            n->where_rowid = true;
+            n->rowid = std::stoll(num);
+        }
+        if (!p.eof()) return nullptr;
+        return n;
+    }
+    return nullptr;
 }
 
 } // namespace tinydb

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -1,10 +1,91 @@
 #include "tinydb/vm.hpp"
+#include <limits>
 
 namespace tinydb {
 
 int VM::run(const std::vector<Instr>& prog) {
-    // Stub VM: just iterate and return 0
-    (void)prog;
+    results_.clear();
+    size_t pc = 0;
+    while (pc < prog.size()) {
+        const Instr& ins = prog[pc];
+        switch (ins.op) {
+        case Op::OpenRead:
+        case Op::OpenWrite: {
+            if (!btree_) return 1;
+            if (cursors_.size() <= static_cast<size_t>(ins.p1))
+                cursors_.resize(ins.p1 + 1);
+            cursors_[ins.p1] = btree_->open(static_cast<uint32_t>(ins.p2));
+            ++pc;
+            break;
+        }
+        case Op::Rewind: {
+            auto& c = cursors_[ins.p1];
+            btree_->seek(c, std::numeric_limits<int64_t>::min());
+            std::string_view payload = btree_->read_payload(c);
+            if (payload.empty()) pc = static_cast<size_t>(ins.p2); else ++pc;
+            break;
+        }
+        case Op::SeekGE: {
+            auto& c = cursors_[ins.p1];
+            int64_t key = 0;
+            if (static_cast<size_t>(ins.p3) < regs_.size()) key = regs_[ins.p3].i;
+            bool found = btree_->seek(c, key);
+            if (!found) pc = static_cast<size_t>(ins.p2); else ++pc;
+            break;
+        }
+        case Op::Next: {
+            auto& c = cursors_[ins.p1];
+            bool ok = btree_->next(c);
+            if (ok) pc = static_cast<size_t>(ins.p2); else ++pc;
+            break;
+        }
+        case Op::Column: {
+            auto& c = cursors_[ins.p1];
+            std::string_view payload = btree_->read_payload(c);
+            auto row = decode_row(reinterpret_cast<const uint8_t*>(payload.data()), payload.size());
+            if (ins.p2 >= 0) {
+                if (regs_.size() <= static_cast<size_t>(ins.p3)) regs_.resize(ins.p3 + 1);
+                if (static_cast<size_t>(ins.p2) < row.size()) regs_[ins.p3] = row[ins.p2];
+            } else {
+                last_row_cols_ = row.size();
+                if (regs_.size() < last_row_cols_) regs_.resize(last_row_cols_);
+                for (size_t i = 0; i < row.size(); ++i) regs_[i] = row[i];
+            }
+            ++pc;
+            break;
+        }
+        case Op::Integer: {
+            if (regs_.size() <= static_cast<size_t>(ins.p2)) regs_.resize(ins.p2 + 1);
+            regs_[ins.p2].tag = ColTag::INT;
+            regs_[ins.p2].i = ins.p1;
+            ++pc;
+            break;
+        }
+        case Op::Insert: {
+            if (!btree_) return 1;
+            std::string_view payload(ins.p4);
+            btree_->insert(static_cast<uint32_t>(ins.p1), {next_rowid_++}, payload);
+            ++pc;
+            break;
+        }
+        case Op::ResultRow: {
+            int n = ins.p2 == 0 ? static_cast<int>(last_row_cols_) : ins.p2;
+            std::vector<Value> row;
+            row.reserve(n);
+            for (int i = 0; i < n; ++i) {
+                if (static_cast<size_t>(ins.p1 + i) < regs_.size())
+                    row.push_back(regs_[ins.p1 + i]);
+                else
+                    row.push_back(Value{});
+            }
+            results_.push_back(std::move(row));
+            ++pc;
+            break;
+        }
+        case Op::Halt:
+            return 0;
+        }
+    }
     return 0;
 }
 

--- a/tests/codegen_tests.cpp
+++ b/tests/codegen_tests.cpp
@@ -1,14 +1,24 @@
 #include "tinydb/parser.hpp"
 #include "tinydb/codegen.hpp"
 #include "tinydb/catalog.hpp"
+#include "tinydb/storage.hpp"
+#include "tinydb/pager.hpp"
+#include "tinydb/btree.hpp"
 #include <cassert>
+#include <memory>
 
 int main() {
-    tinydb::Catalog cat;
-    cat.create_table("t", 1u);
-    auto ast = tinydb::parse("SELECT a,b FROM t");
-    auto prog = tinydb::codegen(*ast, cat);
-    (void)prog;
+    using namespace tinydb;
+    Pager pager(std::make_unique<FileStorage>("codegen.db"));
+    BTree bt(pager);
+    Catalog cat(pager, bt);
+    cat.create_table("t");
+    auto ast = parse("SELECT * FROM t");
+    auto prog = codegen(*ast, cat);
+    assert(!prog.empty());
+    auto ast2 = parse("INSERT INTO t VALUES(1,'x')");
+    auto prog2 = codegen(*ast2, cat);
+    assert(prog2.size() >= 2);
+    pager.flush();
     return 0;
 }
-

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -1,16 +1,26 @@
 #include "tinydb/parser.hpp"
 #include "tinydb/codegen.hpp"
 #include "tinydb/catalog.hpp"
+#include "tinydb/storage.hpp"
+#include "tinydb/pager.hpp"
+#include "tinydb/btree.hpp"
 #include "tinydb/vm.hpp"
 #include <cassert>
+#include <memory>
 
 int main() {
-    tinydb::Catalog cat; cat.create_table("t", 1u);
-    auto ast = tinydb::parse("SELECT a,b FROM t");
-    auto prog = tinydb::codegen(*ast, cat);
-    tinydb::VM vm;
-    int rc = vm.run(prog);
-    assert(rc == 0);
+    using namespace tinydb;
+    Pager pager(std::make_unique<FileStorage>("integration.db"));
+    BTree bt(pager);
+    Catalog cat(pager, bt);
+    cat.create_table("t");
+    VM vm(bt, cat);
+    vm.run(codegen(*parse("INSERT INTO t VALUES(1,'a')"), cat));
+    vm.run(codegen(*parse("INSERT INTO t VALUES(2,'b')"), cat));
+    vm.run(codegen(*parse("SELECT * FROM t WHERE rowid=2"), cat));
+    assert(vm.results().size() == 1);
+    assert(vm.results()[0][0].i == 2);
+    assert(vm.results()[0][1].s == "b");
+    pager.flush();
     return 0;
 }
-

--- a/tests/parser_tests.cpp
+++ b/tests/parser_tests.cpp
@@ -1,12 +1,15 @@
 #include "tinydb/parser.hpp"
 #include <cassert>
-#include <memory>
 
 int main() {
-    auto n1 = tinydb::parse("CREATE TABLE t(a INT, b TEXT)");
-    auto n2 = tinydb::parse("INSERT INTO t VALUES(1,'x')");
-    auto n3 = tinydb::parse("SELECT a,b FROM t");
-    assert(n1 && n2 && n3);
+    using namespace tinydb;
+    auto n1 = parse("CREATE TABLE t(a INT, b TEXT)");
+    auto n2 = parse("INSERT INTO t VALUES(1,'x')");
+    auto n3 = parse("SELECT * FROM t WHERE rowid=1");
+    assert(dynamic_cast<ASTCreate*>(n1.get()));
+    assert(dynamic_cast<ASTInsert*>(n2.get()));
+    auto s = dynamic_cast<ASTSelect*>(n3.get());
+    assert(s && s->where_rowid && s->rowid==1);
+    assert(!parse("BAD SQL"));
     return 0;
 }
-

--- a/tests/vm_tests.cpp
+++ b/tests/vm_tests.cpp
@@ -1,11 +1,29 @@
+#include "tinydb/parser.hpp"
+#include "tinydb/codegen.hpp"
+#include "tinydb/catalog.hpp"
+#include "tinydb/storage.hpp"
+#include "tinydb/pager.hpp"
+#include "tinydb/btree.hpp"
 #include "tinydb/vm.hpp"
 #include <cassert>
+#include <memory>
 
 int main() {
-    tinydb::VM vm;
-    std::vector<tinydb::Instr> prog{{tinydb::Op::Halt,0,0,0,{}}};
-    int rc = vm.run(prog);
-    assert(rc == 0);
+    using namespace tinydb;
+    Pager pager(std::make_unique<FileStorage>("vm.db"));
+    BTree bt(pager);
+    Catalog cat(pager, bt);
+    cat.create_table("t");
+    VM vm(bt, cat);
+    auto ins = parse("INSERT INTO t VALUES(1,'x')");
+    auto prog1 = codegen(*ins, cat);
+    vm.run(prog1);
+    auto sel = parse("SELECT * FROM t");
+    auto prog2 = codegen(*sel, cat);
+    vm.run(prog2);
+    assert(vm.results().size() == 1);
+    assert(vm.results()[0][0].i == 1);
+    assert(vm.results()[0][1].s == "x");
+    pager.flush();
     return 0;
 }
-


### PR DESCRIPTION
## Summary
- Implement recursive-descent SQL parser handling CREATE, INSERT, and SELECT with optional rowid filters
- Add code generator translating AST to VM instructions and expand VM with basic cursor and row operations
- Provide interactive CLI with .open/.schema and SELECT/INSERT/CREATE support

## Testing
- `meson test -C build`


------
https://chatgpt.com/codex/tasks/task_e_68b8b8128cf08321a5498016c8464a37