### PR TITLE
Add WebAssembly shim and line processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,23 @@ meson test -C build --print-errorlogs
 ./build/cli/tinydb
 ```
 
+## WebAssembly
+
+TinyDB can run in the browser via a small C++ shim that exposes
+`tinydb_eval_script` and `tinydb_free`. Compile the sources with
+Emscripten, for example:
+
+```bash
+em++ -std=c++20 -O2 -Iinclude src/*.cpp -sEXPORTED_FUNCTIONS='["_tinydb_eval_script","_tinydb_free"]' -sALLOW_MEMORY_GROWTH=1 -o tinydb.js
+```
+
+From JavaScript you can then evaluate newline-delimited scripts:
+
+```js
+const mod = await Module();
+const ptr = mod.allocateUTF8(script);
+const outPtr = mod._tinydb_eval_script(ptr);
+console.log(mod.UTF8ToString(outPtr));
+mod._tinydb_free(outPtr);
+```
+

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -1,69 +1,15 @@
-#include "tinydb/parser.hpp"
-#include "tinydb/codegen.hpp"
-#include "tinydb/catalog.hpp"
-#include "tinydb/vm.hpp"
-#include "tinydb/storage.hpp"
-#include "tinydb/pager.hpp"
-#include "tinydb/btree.hpp"
-#include <cctype>
+#include "tinydb/repl.hpp"
 #include <iostream>
-#include <memory>
 #include <string>
 
 int main() {
-    using namespace tinydb;
-    std::unique_ptr<Pager> pager;
-    std::unique_ptr<BTree> btree;
-    std::unique_ptr<Catalog> catalog;
-    VM vm;
-    std::string line;
+    std::string line, out;
     std::cout << "tinydb CLI\n";
     while (std::cout << "tinydb> " && std::getline(std::cin, line)) {
-        if (line.empty()) continue;
-        if (line[0] == '.') {
-            if (line.rfind(".open", 0) == 0) {
-                std::string path = line.substr(5);
-                while (!path.empty() && std::isspace(static_cast<unsigned char>(path.front()))) path.erase(path.begin());
-                pager = std::make_unique<Pager>(std::make_unique<FileStorage>(path));
-                btree = std::make_unique<BTree>(*pager);
-                catalog = std::make_unique<Catalog>(*pager, *btree);
-                vm.set_env(*btree, *catalog);
-            } else if (line == ".schema") {
-                if (!catalog) { std::cout << "no db\n"; continue; }
-                for (auto& kv : catalog->tables()) {
-                    std::cout << kv.second.name << "\n";
-                }
-            } else if (line == ".quit" || line == ".exit") {
-                break;
-            } else {
-                std::cout << "unknown command\n";
-            }
-            continue;
-        }
-        if (!catalog) { std::cout << "no database open\n"; continue; }
-        auto ast = parse(line);
-        if (!ast) { std::cout << "parse error\n"; continue; }
-        if (auto c = dynamic_cast<ASTCreate*>(ast.get())) {
-            catalog->create_table(c->table);
-            if (pager) pager->flush();
-            std::cout << "ok\n";
-            continue;
-        }
-        auto prog = codegen(*ast, *catalog);
-        vm.run(prog);
-        if (pager) pager->flush();
-        if (dynamic_cast<ASTSelect*>(ast.get())) {
-            for (auto& row : vm.results()) {
-                for (size_t i = 0; i < row.size(); ++i) {
-                    if (i) std::cout << '|';
-                    if (row[i].tag == ColTag::INT) std::cout << row[i].i;
-                    else std::cout << row[i].s;
-                }
-                std::cout << "\n";
-            }
-        }
+        out.clear();
+        int rc = tinydb_process_line(line, out);
+        if (!out.empty()) std::cout << out;
+        if (rc != 0) break;
     }
-    if (pager) pager->flush();
     return 0;
 }
-

--- a/include/tinydb/repl.hpp
+++ b/include/tinydb/repl.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <string>
+
+// Process a single REPL line. Appends any output (including newlines)
+// to `out` and returns 0 on success. Non-zero return indicates the
+// caller should terminate (e.g. on ".quit").
+extern "C" int tinydb_process_line(const std::string& line, std::string& out);

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,7 @@
 tinydb_sources = files(
   'pager.cpp', 'storage.cpp', 'varint.cpp', 'record.cpp',
-  'btree.cpp', 'catalog.cpp', 'vm.cpp', 'parser.cpp', 'codegen.cpp', 'ast.cpp'
+  'btree.cpp', 'catalog.cpp', 'vm.cpp', 'parser.cpp', 'codegen.cpp', 'ast.cpp',
+  'repl.cpp', 'wasm_shim.cpp'
 )
 
 tinydb_lib = static_library('tinydb',

--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -1,0 +1,69 @@
+#include "tinydb/repl.hpp"
+
+#include "tinydb/parser.hpp"
+#include "tinydb/codegen.hpp"
+#include "tinydb/catalog.hpp"
+#include "tinydb/vm.hpp"
+#include "tinydb/storage.hpp"
+#include "tinydb/pager.hpp"
+#include "tinydb/btree.hpp"
+#include <cctype>
+#include <memory>
+#include <string>
+
+using namespace tinydb;
+
+extern "C" int tinydb_process_line(const std::string& line, std::string& out) {
+    static std::unique_ptr<Pager> pager;
+    static std::unique_ptr<BTree> btree;
+    static std::unique_ptr<Catalog> catalog;
+    static VM vm;
+
+    if (line.empty()) return 0;
+    if (line[0] == '.') {
+        if (line.rfind(".open", 0) == 0) {
+            std::string path = line.substr(5);
+            while (!path.empty() && std::isspace(static_cast<unsigned char>(path.front()))) {
+                path.erase(path.begin());
+            }
+            pager = std::make_unique<Pager>(std::make_unique<FileStorage>(path));
+            btree = std::make_unique<BTree>(*pager);
+            catalog = std::make_unique<Catalog>(*pager, *btree);
+            vm.set_env(*btree, *catalog);
+        } else if (line == ".schema") {
+            if (!catalog) { out += "no db\n"; return 0; }
+            for (auto& kv : catalog->tables()) {
+                out += kv.second.name;
+                out += '\n';
+            }
+        } else if (line == ".quit" || line == ".exit") {
+            return 1;
+        } else {
+            out += "unknown command\n";
+        }
+        return 0;
+    }
+    if (!catalog) { out += "no database open\n"; return 0; }
+    auto ast = parse(line);
+    if (!ast) { out += "parse error\n"; return 0; }
+    if (auto c = dynamic_cast<ASTCreate*>(ast.get())) {
+        catalog->create_table(c->table);
+        if (pager) pager->flush();
+        out += "ok\n";
+        return 0;
+    }
+    auto prog = codegen(*ast, *catalog);
+    vm.run(prog);
+    if (pager) pager->flush();
+    if (dynamic_cast<ASTSelect*>(ast.get())) {
+        for (auto& row : vm.results()) {
+            for (size_t i = 0; i < row.size(); ++i) {
+                if (i) out.push_back('|');
+                if (row[i].tag == ColTag::INT) out += std::to_string(row[i].i);
+                else out += row[i].s;
+            }
+            out.push_back('\n');
+        }
+    }
+    return 0;
+}

--- a/src/wasm_shim.cpp
+++ b/src/wasm_shim.cpp
@@ -1,0 +1,42 @@
+#include <string>
+#include <sstream>
+#include <vector>
+#include <cstring>
+#include <memory>
+#include <cstdio>
+#include <cstdlib>
+
+extern "C" {
+// Your existing CLI entry points you call inside main.cpp, refactor them if needed:
+int tinydb_process_line(const std::string& line, std::string& out); 
+// ^ Implement by extracting the REPL's single-line handling from your CLI.
+// Should append to `out` (including newlines) and return 0 on success.
+}
+
+extern "C" {
+
+// Returns a heap-allocated C string with the combined output.
+// Caller (JS) must free with `tinydb_free`.
+const char* tinydb_eval_script(const char* script_cstr) {
+    if (!script_cstr) return nullptr;
+    std::istringstream in(script_cstr);
+    std::string line, out;
+    while (std::getline(in, line)) {
+        // Skip empty lines to be friendly
+        if (line.empty()) continue;
+        // Process each line using your existing REPL handler
+        tinydb_process_line(line, out);
+    }
+    // Allocate a C-string to return
+    char* buf = (char*)malloc(out.size() + 1);
+    if (!buf) return nullptr;
+    std::memcpy(buf, out.data(), out.size());
+    buf[out.size()] = '\0';
+    return buf;
+}
+
+void tinydb_free(const char* p) {
+    free((void*)p);
+}
+
+}


### PR DESCRIPTION
## Summary
- Extract REPL line handling into reusable `tinydb_process_line` function.
- Introduce a C-compatible WebAssembly shim exposing `tinydb_eval_script` and `tinydb_free`.
- Wire CLI and build to use the new line processor and document WebAssembly usage.

## Testing
- `meson test -C build`


------
https://chatgpt.com/codex/tasks/task_e_68b8c5476c4883219366387895282799